### PR TITLE
Fix for rt70740

### DIFF
--- a/URI/QueryParam.pm
+++ b/URI/QueryParam.pm
@@ -8,38 +8,30 @@ sub URI::_query::query_param {
 
     if (@_ == 0) {
 	# get keys
-	my %seen;
-	my @keys;
-	for (my $i = 0; $i < @old; $i += 2) {
-	    push(@keys, $old[$i]) unless $seen{$old[$i]}++;
-	}
-	return @keys;
+	my (%seen, $i);
+	return grep !($i++ % 2 || $seen{$_}++), @old;
     }
 
     my $key = shift;
-    my @i;
-
-    for (my $i = 0; $i < @old; $i += 2) {
-	push(@i, $i) if $old[$i] eq $key;
-    }
+    my @i = grep $_ % 2 == 0 && $old[$_] eq $key, 0 .. $#old;
 
     if (@_) {
 	my @new = @old;
 	my @new_i = @i;
 	my @vals = map { ref($_) eq 'ARRAY' ? @$_ : $_ } @_;
-	#print "VALS:@vals [@i]\n";
+
 	while (@new_i > @vals) {
-	    #print "REMOVE $new_i[-1]\n";
-	    splice(@new, pop(@new_i), 2);
+	    splice @new, pop @new_i, 2;
 	}
-	while (@vals > @new_i) {
+	if (@vals > @new_i) {
 	    my $i = @new_i ? $new_i[-1] + 2 : @new;
-	    #print "SPLICE $i\n";
-	    splice(@new, $i, 0, $key => pop(@vals));
+	    my @splice = splice @vals, @new_i, @vals - @new_i;
+
+	    splice @new, $i, 0, map { $key => $_ } @splice;
 	}
-	for (@vals) {
+	if (@vals) {
 	    #print "SET $new_i[0]\n";
-	    $new[shift(@new_i)+1] = $_;
+	    @new[ map $_ + 1, @new_i ] = @vals;
 	}
 
 	$self->query_form(\@new);
@@ -51,7 +43,8 @@ sub URI::_query::query_param {
 sub URI::_query::query_param_append {
     my $self = shift;
     my $key = shift;
-    $self->query_form($self->query_form, $key => \@_);  # XXX
+    my @vals = map { ref $_ eq 'ARRAY' ? @$_ : $_ } @_;
+    $self->query_form($self->query_form, $key => \@vals);  # XXX
     return;
 }
 

--- a/t/query-param.t
+++ b/t/query-param.t
@@ -1,87 +1,72 @@
 #!perl -w
 
-print "1..18\n";
-
 use strict;
+
+use Test::More tests => 19;
 
 use URI;
 use URI::QueryParam;
 
 my $u = URI->new("http://www.sol.no?foo=4&bar=5&foo=5");
 
-my $h = $u->query_form_hash;
-print "not " unless $h->{foo}[0] eq "4" && $h->{foo}[1] eq "5" && $h->{bar} eq "5";
-print "ok 1\n";
+is_deeply(
+    $u->query_form_hash,
+    { foo => [ 4, 5 ], bar => 5 },
+    'query_form_hash get'
+);
 
 $u->query_form_hash({ a => 1, b => 2});
-print "not " unless $u->query eq "a=1&b=2" || $u->query eq "b=2&a=1";
-print "ok 2\n";
+ok $u->query eq "a=1&b=2" || $u->query eq "b=2&a=1", 'query_form_hash set';
 
 $u->query("a=1&b=2&a=3&b=4&a=5");
-print "not " unless $u->query_param == 2 && join(":", $u->query_param) eq "a:b";
-print "ok 3\n";
+is join(':', $u->query_param), "a:b", 'query_param list keys';
 
-print "not " unless $u->query_param("a") eq "1" &&
-                    join(":", $u->query_param("a")) eq "1:3:5";
-print "ok 4\n";
+is $u->query_param("a"), "1", "query_param scalar return";
+is join(":", $u->query_param("a")), "1:3:5", "query_param list return";
 
-print "not " unless $u->query_param(a => 11 .. 14) eq "1";
-print "ok 5\n";
+is $u->query_param(a => 11 .. 15), 1, "query_param set return";
 
-print "not " unless $u->query eq "a=11&b=2&a=12&b=4&a=13&a=14";
-print "ok 6\n";
+is $u->query, "a=11&b=2&a=12&b=4&a=13&a=14&a=15", "param order";
 
-print "not " unless join(":", $u->query_param(a => 11)) eq "11:12:13:14";
-print "ok 7\n";
+is join(":", $u->query_param(a => 11)), "11:12:13:14:15", "old values returned";
 
-print "not " unless $u->query eq "a=11&b=2&b=4";
-print "ok 8\n";
+is $u->query, "a=11&b=2&b=4";
 
-print "not " unless $u->query_param_delete("a") eq "11";
-print "ok 9\n";
+is $u->query_param_delete("a"), "11", 'query_param_delete';
 
-print "not " unless $u->query eq "b=2&b=4";
-print "ok 10\n";
+is $u->query, "b=2&b=4";
 
 $u->query_param_append(a => 1, 3, 5);
 $u->query_param_append(b => 6);
 
-print "not " unless $u->query eq "b=2&b=4&a=1&a=3&a=5&b=6";
-print "ok 11\n";
+is $u->query, "b=2&b=4&a=1&a=3&a=5&b=6";
 
 $u->query_param(a => []);  # same as $u->query_param_delete("a");
 
-print "not " unless $u->query eq "b=2&b=4&b=6";
-print "ok 12\n";
+is $u->query, "b=2&b=4&b=6", 'delete by assigning empty list';
 
 $u->query(undef);
 $u->query_param(a => 1, 2, 3);
 $u->query_param(b => 1);
 
-print "not " unless $u->query eq 'a=3&a=2&a=1&b=1';
-print "ok 13\n";
+is $u->query, 'a=1&a=2&a=3&b=1', 'query_param from scratch';
 
 $u->query_param_delete('a');
 $u->query_param_delete('b');
 
-print "not " if $u->query;
-print "ok 14\n";
+ok ! $u->query;
 
-print "not " unless $u->as_string eq 'http://www.sol.no';
-print "ok 15\n";
+is $u->as_string, 'http://www.sol.no';
 
 $u->query(undef);
 $u->query_param(a => 1, 2, 3);
 $u->query_param(b => 1);
 
-print "not " unless $u->query eq 'a=3&a=2&a=1&b=1';
-print "ok 16\n";
+is $u->query, 'a=1&a=2&a=3&b=1';
 
 $u->query_param('a' => []);
 $u->query_param('b' => []);
 
-print "not " if $u->query;
-print "ok 17\n";
+ok ! $u->query;
 
-print "not " unless $u->as_string eq 'http://www.sol.no';
-print "ok 18\n";
+is $u->as_string, 'http://www.sol.no';


### PR DESCRIPTION
When adding new values to a query, they would appear in reverse order
when adding from scratch, but in the specified order when adding to an
existing key.

This change makes the order items are added to the query consistent.

It also brings the interface of query_param_append in line with that of
query_param, supporting array refs as well as simple lists.

Updated tests to check for the new behaviour and use Test::More, which
was in core at the minimum perl version specified in the Makefile.PL
