### PR TITLE
Don't omit "/" if it has QUERY_STRING.

### DIFF
--- a/URI/http.pm
+++ b/URI/http.pm
@@ -12,8 +12,7 @@ sub canonical
     my $self = shift;
     my $other = $self->SUPER::canonical;
 
-    my $slash_path = defined($other->authority) &&
-        !length($other->path) && !defined($other->query);
+    my $slash_path = defined($other->authority) && !length($other->path);
 
     if ($slash_path) {
 	$other = $other->clone if $other == $self;

--- a/t/http.t
+++ b/t/http.t
@@ -1,6 +1,6 @@
 #!perl -w
 
-print "1..15\n";
+print "1..16\n";
 
 use URI;
 
@@ -60,4 +60,9 @@ print "ok 14\n";
 $u = URI->new("http://%77%77%77%2e%70%65%72%6c%2e%63%6f%6d/%70%75%62/%61/%32%30%30%31/%30%38/%32%37/%62%6a%6f%72%6e%73%74%61%64%2e%68%74%6d%6c");
 print "not " unless $u->canonical eq "http://www.perl.com/pub/a/2001/08/27/bjornstad.html";
 print "ok 15\n";
+
+# RFC 1738: "/" can't be ommited when <searchpart> is present.
+$u = URI->new("http://localhost?p=1");
+print "not " unless $u->canonical eq "http://localhost/?p=1";
+print "ok 16\n";
 


### PR DESCRIPTION
RFC 1738 says, `If neither &lt;path> nor &lt;searchpart> is present, the "/" may also be omitted.'.

http://www.rfc-editor.org/rfc/rfc1738.txt

So we can't omit "/" if the URL has '?' and QUERY_STRINGs.

I thought that the following patch is better than this pull-req, but it makes t/old-base.t broken.

``` diff
diff --git a/URI/http.pm b/URI/http.pm
index cb69822..8631e40 100644
--- a/URI/http.pm
+++ b/URI/http.pm
@@ -13,7 +13,7 @@ sub canonical
     my $other = $self->SUPER::canonical;

     my $slash_path = defined($other->authority) &&
-        !length($other->path) && !defined($other->query);
+        !length($other->path) && defined($other->query);

     if ($slash_path) {
        $other = $other->clone if $other == $self;
diff --git a/t/http.t b/t/http.t
index 2b8c44b..65e32cd 100644
--- a/t/http.t
+++ b/t/http.t
@@ -1,6 +1,6 @@
 #!perl -w

-print "1..15\n";
+print "1..17\n";

 use URI;

@@ -61,3 +61,12 @@ $u = URI->new("http://%77%77%77%2e%70%65%72%6c%2e%63%6f%6d/%7
 print "not " unless $u->canonical eq "http://www.perl.com/pub/a/2001/08/27/bjor
 print "ok 15\n";

+# RFC 1738: "/" can't be ommited when <searchpart> is present.
+$u = URI->new("http://localhost?p=1");
+print "not " unless $u->canonical eq "http://localhost/?p=1";
+print "ok 16\n";
+
+$u = URI->new("http://localhost");
+print "not " unless $u->canonical eq "http://localhost";
+print "ok 17\n";
+
```
