### PR TITLE
Use $ENV{TMPDIR} if defined

### DIFF
--- a/t/old-base.t
+++ b/t/old-base.t
@@ -654,7 +654,7 @@ sub newlocal_test {
 	      ($^O eq 'qnx' ? '/usr/bin/fullpath -t' :
               ($^O eq 'VMS' ? 'show default' :
               (-e '/bin/pwd' ? '/bin/pwd' : 'pwd'))));
-    my $tmpdir = ($^O eq 'MSWin32' ? $ENV{TEMP} : '/tmp');
+    my $tmpdir = ($^O eq 'MSWin32' ? $ENV{TEMP} : $ENV{TMPDIR} || '/tmp');
     if ( $^O eq 'qnx' ) {
 	$tmpdir = `/usr/bin/fullpath -t $tmpdir`;
 	chomp $tmpdir;


### PR DESCRIPTION
This package can't be built on Android. On this system there is no /tmp directory. It is better to utilise $TMPDIR environment variable so the test pass on any system with proper directory in $TMPDIR.
