### PR TITLE
Add sftp scheme

### DIFF
--- a/URI/sftp.pm
+++ b/URI/sftp.pm
@@ -1,0 +1,5 @@
+package URI::sftp;
+require URI::ssh;
+@ISA=qw(URI::ssh);
+
+1;


### PR DESCRIPTION
This is just an alias to ssh.  However, URI::sftp is already out on CPAN, written by @salva.  We'll need his permission to include it here.

His also includes a redirect of path to path_query to prevent query string parsing.  Given that ssh, sftp, or scp don't have query strings either, that's probably best to include into URI::ssh instead, and let the other two modules gain that change through inheritance.