### PR TITLE
_query.pm: Sort hash keys if given a hash.

### DIFF
--- a/URI/_query.pm
+++ b/URI/_query.pm
@@ -38,7 +38,7 @@ sub query_form {
         }
         elsif (ref($r) eq "HASH") {
             $delim = $_[1];
-            @_ = %$r;
+            @_ = map { $_ => $r->{$_} } sort keys %$r;
         }
         $delim = pop if @_ % 2;
 

--- a/t/sort-hash-query-form.t
+++ b/t/sort-hash-query-form.t
@@ -1,0 +1,22 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+# ABSTRACT: Make sure query_form(\%hash) is sorted
+
+use URI;
+
+my $base = URI->new('http://example.org/');
+
+my $i = 1;
+
+my $hash = { map { $_ => $i++ } qw( a b c d e f ) };
+
+$base->query_form($hash);
+
+is("$base","http://example.org/?a=1&b=2&c=3&d=4&e=5&f=6", "Query parameters are sorted");
+
+done_testing;
+
+


### PR DESCRIPTION
Hashes already have an unpredictable ordering, so any code that relies
on order retention while passing a hash object is already broken.

However, there's some utility in having consistent URI's **generated**
from unpredictable hashes if those URIs ever go through a caching layer
somewhere.

I considered having some kind of tunable variable to indicate if it
sorts or not, but figured YAGNI, so didn't.