### PR TITLE
Clarify how query_param method is to be used.

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,6 +5,10 @@ Revision history for URI
 
     - add $VERSIONs for all modules that lack them
 
+  Olaf Alders
+
+    - Clarify use of query_param() method
+
 
 2015-06-25   Karen Etheridge <ether@cpan.org>
 

--- a/lib/URI/QueryParam.pm
+++ b/lib/URI/QueryParam.pm
@@ -141,6 +141,17 @@ parameters with the given key.  If any of the values provided are
 array references, then the array is dereferenced to get the actual
 values.
 
+Please note that you can supply multiple values to this method, but you cannot
+supply multiple keys.
+
+Do this:
+
+    $uri->query_param( widget_id => 1, 5, 9 );
+
+Do NOT do this:
+
+    $uri->query_param( widget_id => 1, frobnicator_id => 99 );
+
 =item $u->query_param_append($key, $value,...)
 
 Adds new parameters with the given


### PR DESCRIPTION
This might seem obvious to others, but it bit me earlier today.  I think it's because it's not clear what the ellipsis in `=item $u->query_param( $key, $value,... )` represents.  The current docs do accurately describe the current behaviour, but it's subtle enough that it's easy to overlook. 

Because of context, something like `$u->query_param( key => 'value', key_2 => 'value_2' )` doesn't throw an exception.  It just returns something you couldn't possibly want.

Yes, I could also refresh my memory as to how the `CGI.pm` `param()` method works, but I'm not sure we need to push people in that direction.