### PR TITLE
updated changelog from 1.57 rt 105983

### DIFF
--- a/Changes
+++ b/Changes
@@ -147,6 +147,9 @@ Revision history for URI
 
   Release 1.57
 
+  Perl 5.6 is no longer supported, use backpan to obtain obsolete versions
+  of uri.
+
   Mark Stosberg (8):
       typo fix: s/do deal/to deal/
       best practice: s/foreach /for /


### PR DESCRIPTION
This is the most trivial bug I could find to fix, it is just an update to the changelog entry for 1.57 to indicate that perl 5.6 is no longer supported. (I don't think this warrants a further revision to the changelog to indicate that a prior entry was corrected)

The policy as I understand it is for upstream modules such as this to support at least Perl 5.8. Last month I helped David Golden maintain 5.8 support in Path::Tiny for my pull request challenge contribution. 

I was looking at uri for the pull request challenge, there are  45 rtcpan bugs in either new or open plus a few more reported on github. In reviewing them I believe that many can be either marked closed or rejected, which makes it more confusing as someone just volunteering a few hours to help out to pick a task to work on.