### PR TITLE
Add samples to ->host and ->ihost in POD

### DIFF
--- a/lib/URI.pm
+++ b/lib/URI.pm
@@ -755,9 +755,14 @@ value from $uri->host.  When setting the host attribute to an IPv6 address you
 can use a raw address or one enclosed in brackets.  The address needs to be
 enclosed in brackets if you want to pass in a new port value as well.
 
+Sample: Returns I<www.xn--ri-sample-fra0f> for I<http://www.E<0xC3>E<0xBC>ri-sample/foo/bar.html>
+
 =item $uri->ihost
 
-Returns the host in Unicode form.  Any IDNA A-labels are turned into U-labels.
+Returns the host in Unicode form. Any IDNA A-labels (encoded unicode chars with
+I<xn--> prefix) are turned into U-labels (unicode chars).
+
+Sample: Returns I<www.E<0xC3>E<0xBC>ri-sample> for I<http://www.E<0xC3>E<0xBC>ri-sample/foo/bar.html>
 
 =item $uri->port
 


### PR DESCRIPTION
I like samples, because they usually speed up understanding of the documentation. Just tried ->host and ->ihost and thought that the POD could be better at this point.
Really small change.
