### PR TITLE
Localize $@ when evaling

### DIFF
--- a/lib/URI.pm
+++ b/lib/URI.pm
@@ -129,6 +129,7 @@ sub implementor
     # check we actually have one for the scheme:
     unless (@{"${ic}::ISA"}) {
         # Try to load it
+        local $@;
         eval "require $ic";
         die $@ if $@ && $@ !~ /Can\'t locate.*in \@INC/;
         return undef unless @{"${ic}::ISA"};

--- a/lib/URI/urn.pm
+++ b/lib/URI/urn.pm
@@ -30,6 +30,7 @@ sub _init {
 	no strict 'refs';
 	unless (@{"${impclass}::ISA"}) {
 	    # Try to load it
+            local $@;
 	    eval "require $impclass";
 	    die $@ if $@ && $@ !~ /Can\'t locate.*in \@INC/;
 	    $impclass = "URI::urn" unless @{"${impclass}::ISA"};


### PR DESCRIPTION
We experienced an issue at $work where trying to check a javascript:// set $@, and exception code on our side later died with the URI exception.