### PR TITLE
Fix t/distmanifest.t

### DIFF
--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -7,4 +7,11 @@
 ^MANIFEST.SKIP$
 ^\.ackrc$
 ^URI-\d
-^.mailmap$
+^\.git
+^\.mailmap$
+^\.travis\.yml$
+^Makefile$
+^MYMETA\.json$
+^MYMETA\.yml$
+^blib
+^pm_to_blib$

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -82,6 +82,7 @@ my %WriteMakefileArgs = (
                 requires => {
                     'Test::More' => '0.96',
                     'File::Temp' => '0',
+					'Test::DistManifest' => '1.014',
                 },
             },
         },


### PR DESCRIPTION
Test::DistManifest requirement was missing in Makefile.PL, causing test
t/distmanifest.t to fail. Fixed.

MANIFEST.SKIP extended to include more non-MANIFEST files, so that
t/distmanifest.t passes.