### PR TITLE
remove CheckChangeLog from dist.ini

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -63,9 +63,6 @@ authority = cpan:LWWWP
 
 [MakeMaker]
 
-[CheckChangeLog]
-filename = Changes
-
 [CheckChangesHasContent]
 ; TODO strict and warnings to quiet the kwalitee tests
 ; [Test::Kwalitee]


### PR DESCRIPTION
We increment VERSION after releases, but it conflicts with Dist::Zilla::Plugin::CheckChangeLog.
See https://gist.github.com/skaji/66032425e0be47552f0184e73a15d7ec.

Because we have CheckChangesHasContent, we can remove CheckChangeLog, I guess.

@genio @oalders Could you review this please?