### PR TITLE
URI::_punycode - Privatize functions

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Revision history for URI
 
 {{$NEXT}}
     - Update documentation for URI::_punycode (GH Issue #45)
+    - Prefix private methods with _ in URI::_punycode (GH Issue #47)
 
 1.72      2017-07-25
     - Convert the dist to Dist::Zilla for authoring.

--- a/dist.ini
+++ b/dist.ini
@@ -101,7 +101,6 @@ trustme = URI::Heuristic => qr/^(?:MY_COUNTRY|uf_url|uf_urlstr)$/
 trustme = URI::URL => qr/^(?:address|article|crack|dos_path|encoded822addr|eparams|epath|frag)$/
 trustme = URI::URL => qr/^(?:full_path|groupart|keywords|local_path|mac_path|netloc|newlocal|params|path|path_components|print_on|query|strict|unix_path|url|vms_path)$/
 trustme = URI::WithBase => qr/^(?:can|clone|eq|new_abs)$/
-trustme = URI::_punycode => qr/^(?:adapt|code_point|digit_value|min)$/
 trustme = URI::_query => qr/^(?:equery|query|query_form|query_form_hash|query_keywords|query_param|query_param_append|query_param_delete)$/
 trustme = URI::_segment => qr/^(?:new)$/
 trustme = URI::_userpass => qr/^(?:password|user)$/

--- a/lib/URI/_punycode.pm
+++ b/lib/URI/_punycode.pm
@@ -26,7 +26,7 @@ my $BasicRE   = qr/[\x00-\x7f]/;
 
 sub _croak { require Carp; Carp::croak(@_); }
 
-sub digit_value {
+sub _digit_value {
     my $code = shift;
     return ord($code) - ord("A") if $code =~ /[A-Z]/;
     return ord($code) - ord("a") if $code =~ /[a-z]/;
@@ -34,14 +34,14 @@ sub digit_value {
     return;
 }
 
-sub code_point {
+sub _code_point {
     my $digit = shift;
     return $digit + ord('a') if 0 <= $digit && $digit <= 25;
     return $digit + ord('0') - 26 if 26 <= $digit && $digit <= 36;
     die 'NOT COME HERE';
 }
 
-sub adapt {
+sub _adapt {
     my($delta, $numpoints, $firsttime) = @_;
     $delta = $firsttime ? $delta / DAMP : $delta / 2;
     $delta += $delta / $numpoints;
@@ -72,7 +72,7 @@ sub decode_punycode {
     LOOP:
 	for (my $k = BASE; 1; $k += BASE) {
 	    my $cp = substr($code, 0, 1, '');
-	    my $digit = digit_value($cp);
+	    my $digit = _digit_value($cp);
 	    defined $digit or return _croak("invalid punycode input");
 	    $i += $digit * $w;
 	    my $t = ($k <= $bias) ? TMIN
@@ -80,7 +80,7 @@ sub decode_punycode {
 	    last LOOP if $digit < $t;
 	    $w *= (BASE - $t);
 	}
-	$bias = adapt($i - $oldi, @output + 1, $oldi == 0);
+	$bias = _adapt($i - $oldi, @output + 1, $oldi == 0);
 	warn "bias becomes $bias" if $DEBUG;
 	$n += $i / (@output + 1);
 	$i = $i % (@output + 1);
@@ -107,7 +107,7 @@ sub encode_punycode {
     warn "basic codepoints: (@output)" if $DEBUG;
 
     while ($h < @input) {
-	my $m = min(grep { $_ >= $n } map ord, @input);
+	my $m = _min(grep { $_ >= $n } map ord, @input);
 	warn sprintf "next code point to insert is %04x", $m if $DEBUG;
 	$delta += ($m - $n) * ($h + 1);
 	$n = $m;
@@ -121,12 +121,12 @@ sub encode_punycode {
 		    my $t = ($k <= $bias) ? TMIN :
 			($k >= $bias + TMAX) ? TMAX : $k - $bias;
 		    last LOOP if $q < $t;
-		    my $cp = code_point($t + (($q - $t) % (BASE - $t)));
+		    my $cp = _code_point($t + (($q - $t) % (BASE - $t)));
 		    push @output, chr($cp);
 		    $q = ($q - $t) / (BASE - $t);
 		}
-		push @output, chr(code_point($q));
-		$bias = adapt($delta, $h + 1, $h == $b);
+		push @output, chr(_code_point($q));
+		$bias = _adapt($delta, $h + 1, $h == $b);
 		warn "bias becomes $bias" if $DEBUG;
 		$delta = 0;
 		$h++;
@@ -138,7 +138,7 @@ sub encode_punycode {
     return join '', @output;
 }
 
-sub min {
+sub _min {
     my $min = shift;
     for (@_) { $min = $_ if $_ <= $min }
     return $min;


### PR DESCRIPTION
Update URI::_punycode to make several functions that have never
been documented and have always been considered private to
actually be private.

* adapt -> _adapt
* code_point -> _code_point
* digit_value ->  _digit_value
* min -> _min

This allows us to remove some special casing in the dist.ini conf
file, reducing complexity.