### PR TITLE
silence "Use of uninitialized value in lc" warning

### DIFF
--- a/lib/URI/file/Base.pm
+++ b/lib/URI/file/Base.pm
@@ -66,8 +66,8 @@ sub _file_is_localhost
     return 1 if $host eq "localhost";
     eval {
 	require Net::Domain;
-	lc(Net::Domain::hostfqdn()) eq $host ||
-	lc(Net::Domain::hostname()) eq $host;
+	lc(Net::Domain::hostfqdn() || '') eq $host ||
+	lc(Net::Domain::hostname() || '') eq $host;
     };
 }
 


### PR DESCRIPTION
This PR should fix the following warning in t/old-file.t.
```
❯ prove -l t/old-file.t
t/old-file.t .. 1/12 Use of uninitialized value in lc at /Users/skaji/src/github.com/libwww-perl/URI/lib/URI/file/Base.pm line 69.
Use of uninitialized value in lc at /Users/skaji/src/github.com/libwww-perl/URI/lib/URI/file/Base.pm line 69.
Use of uninitialized value in lc at /Users/skaji/src/github.com/libwww-perl/URI/lib/URI/file/Base.pm line 69.
Use of uninitialized value in lc at /Users/skaji/src/github.com/libwww-perl/URI/lib/URI/file/Base.pm line 69.
Use of uninitialized value in lc at /Users/skaji/src/github.com/libwww-perl/URI/lib/URI/file/Base.pm line 69.
Use of uninitialized value in lc at /Users/skaji/src/github.com/libwww-perl/URI/lib/URI/file/Base.pm line 69.
Use of uninitialized value in lc at /Users/skaji/src/github.com/libwww-perl/URI/lib/URI/file/Base.pm line 69.
Use of uninitialized value in lc at /Users/skaji/src/github.com/libwww-perl/URI/lib/URI/file/Base.pm line 69.
Use of uninitialized value in lc at /Users/skaji/src/github.com/libwww-perl/URI/lib/URI/file/Base.pm line 69.
Use of uninitialized value in lc at /Users/skaji/src/github.com/libwww-perl/URI/lib/URI/file/Base.pm line 69.
Use of uninitialized value in lc at /Users/skaji/src/github.com/libwww-perl/URI/lib/URI/file/Base.pm line 69.
Use of uninitialized value in lc at /Users/skaji/src/github.com/libwww-perl/URI/lib/URI/file/Base.pm line 69.
t/old-file.t .. ok
All tests successful.
Files=1, Tests=12,  0 wallclock secs ( 0.02 usr  0.01 sys +  0.05 cusr  0.05 csys =  0.13 CPU)
Result: PASS
```