### PR TITLE
patching #57, $uri->canonical unconditionally returns a clone

### DIFF
--- a/lib/URI.pm
+++ b/lib/URI.pm
@@ -302,21 +302,22 @@ sub canonical
     # Make sure scheme is lowercased, that we don't escape unreserved chars,
     # and that we use upcase escape sequences.
 
-    my $self = shift;
-    my $scheme = $self->_scheme || "";
-    my $uc_scheme = $scheme =~ /[A-Z]/;
-    my $esc = $$self =~ /%[a-fA-F0-9]{2}/;
-    return $self unless $uc_scheme || $esc;
+    # We now clone unconditionally; see
+    # https://github.com/libwww-perl/URI/issues/57
 
-    my $other = $self->clone;
-    if ($uc_scheme) {
-	$other->_scheme(lc $scheme);
-    }
+    my $other = $_[0]->clone;
+    my $scheme = $other->_scheme || "";
+    my $uc_scheme = $scheme =~ /[A-Z]/;
+    my $esc = $$other =~ /%[a-fA-F0-9]{2}/;
+    return $other unless $uc_scheme || $esc;
+
+    $other->_scheme(lc $scheme) if $uc_scheme;
+
     if ($esc) {
-	$$other =~ s{%([0-9a-fA-F]{2})}
-	            { my $a = chr(hex($1));
+        $$other =~ s{%([0-9a-fA-F]{2})}
+                    { my $a = chr(hex($1));
                       $a =~ /^[$unreserved]\z/o ? $a : "%\U$1"
-                    }ge;
+                  }ge;
     }
     return $other;
 }
@@ -571,8 +572,12 @@ removing the explicit port specification if it matches the default port,
 uppercasing all escape sequences, and unescaping octets that can be
 better represented as plain characters.
 
-For efficiency reasons, if the $uri is already in normalized form,
-then a reference to it is returned instead of a copy.
+Before version 1.75, this method would return the original unchanged
+C<$uri> object if it detected nothing to change. To make the return
+value consistent (and since the efficiency gains from this behaviour
+were marginal), this method now unconditionally returns a clone. This
+means idioms like C<< $uri->clone->canonical >> are no longer
+necessary.
 
 =item $uri->eq( $other_uri )
 

--- a/t/generic.t
+++ b/t/generic.t
@@ -1,9 +1,10 @@
 use strict;
 use warnings;
 
-print "1..48\n";
+print "1..49\n";
 
 use URI;
+use Scalar::Util qw(refaddr);
 
 my $foo = URI->new("Foo:opaque#frag");
 
@@ -217,3 +218,8 @@ $old = $foo->query("q");
 print "not " unless !defined($old) && $foo eq "?q";
 print "ok 48\n";
 
+# canonical must always be a clone
+my $c1 = $foo->canonical; # canonicalize first
+my $c2 = $c1->canonical;  # canonicalize again
+print 'not ' if refaddr($c1) == refaddr($c2) or $$c1 ne $$c2;
+print "ok 49\n";


### PR DESCRIPTION
This change makes `$uri->canonical` uniformly return a cloned object. Erstwhile it returned `$self` if there was nothing to change, for the stated purpose of efficiency, although benchmarks suggest this turns out to be only about a 7% gain on an operation that is measured in microseconds, and only in the no-op scenario.