### PR TITLE
parse and generate mixed form/keywords queries

### DIFF
--- a/t/old-base.t
+++ b/t/old-base.t
@@ -338,9 +338,13 @@ sub parts_test {
     $url->equery('&=&=b&a=&a&a=b=c&&a=b');
     @a = $url->query_form;
     #note join(":", @a), "\n";
-    is(scalar(@a), 16, 'length');
+    is(scalar(@a), 10, 'length');
     ok(
-       $a[4]  eq ""  && $a[5]  eq "b" && $a[10] eq "a" && $a[11] eq "b=c",
+        $a[0] eq "" && $a[1] eq "" &&
+            $a[2] eq "" && $a[3]  eq "b" &&
+            $a[4] eq "a" && $a[5]  eq "" &&
+            $a[6] eq "a" && $a[7] eq "b=c" &&
+            $a[8] eq "a" && $a[9]  eq "b",
        'sequence',
     );
 

--- a/t/query.t
+++ b/t/query.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 23;
+use Test::More tests => 24;
 
 use URI ();
 my $u = URI->new("", "http");
@@ -79,3 +79,7 @@ $u->query_form([]);
     $u->query_form(a => 1, b => 2);
 }
 is $u, "?a=1;b=2";
+
+$u->query_elements([]);
+$u->query_elements([qw(a b)],{c=>[1,2]},[qw(x y z)],{p=>3});
+is $u, "?a+b&c=1&c=2&x+y+z&p=3";


### PR DESCRIPTION
This is a possible solution for #34 

`query_elements` parses and generates keywords and key=value query elements

`query_form` and `query_keywords` behave nearly exactly as before

only difference: for "weird" queries like `a=b&c`, `c` is now considered a keyword, not a form param.

This may break things?

I'll be sending another, more conservative PR in a bit.