### PR TITLE
handle form params without values, using arrays

### DIFF
--- a/lib/URI/_query.pm
+++ b/lib/URI/_query.pm
@@ -50,11 +50,16 @@ sub query_form {
 	    $key =~ s/([;\/?:@&=+,\$\[\]%])/ URI::Escape::escape_char($1)/eg;
 	    $key =~ s/ /+/g;
 	    $vals = [ref($vals) eq "ARRAY" ? @$vals : $vals];
-            for my $val (@$vals) {
-                $val = '' unless defined $val;
-		$val =~ s/([;\/?:@&=+,\$\[\]%])/ URI::Escape::escape_char($1)/eg;
-                $val =~ s/ /+/g;
-                push(@query, "$key=$val");
+            if (@$vals) {
+                for my $val (@$vals) {
+                    $val = '' unless defined $val;
+                    $val =~ s/([;\/?:@&=+,\$\[\]%])/ URI::Escape::escape_char($1)/eg;
+                    $val =~ s/ /+/g;
+                    push(@query, "$key=$val");
+                }
+            }
+            else {
+                push(@query,$key);
             }
         }
         if (@query) {
@@ -70,8 +75,8 @@ sub query_form {
     }
     return if !defined($old) || !length($old) || !defined(wantarray);
     return unless $old =~ /=/; # not a form
-    map { s/\+/ /g; uri_unescape($_) }
-         map { /=/ ? split(/=/, $_, 2) : ($_ => '')} split(/[&;]/, $old);
+    map { ref($_) ? $_ : do { s/\+/ /g; uri_unescape($_) } }
+         map { /=/ ? split(/=/, $_, 2) : ($_ => [])} split(/[&;]/, $old);
 }
 
 # Handle ...?dog+bones type of query

--- a/t/query.t
+++ b/t/query.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 23;
+use Test::More tests => 25;
 
 use URI ();
 my $u = URI->new("", "http");
@@ -79,3 +79,10 @@ $u->query_form([]);
     $u->query_form(a => 1, b => 2);
 }
 is $u, "?a=1;b=2";
+
+$u->query('a&b=2');
+@q = $u->query_form;
+like join(":", @q), qr/^a:ARRAY\(.+\):b:2$/;
+
+$u->query_form(@q);
+is $u,'?a&b=2';


### PR DESCRIPTION
This is a possible solution for #34 

`query_form` now parses equal-less params, returning them as `$key => []`. This also round-trips.

This is a change in interface, though: previously, empty strings were returned.