### PR TITLE
handle form params without values, using undef

### DIFF
--- a/lib/URI/_query.pm
+++ b/lib/URI/_query.pm
@@ -51,10 +51,14 @@ sub query_form {
 	    $key =~ s/ /+/g;
 	    $vals = [ref($vals) eq "ARRAY" ? @$vals : $vals];
             for my $val (@$vals) {
-                $val = '' unless defined $val;
-		$val =~ s/([;\/?:@&=+,\$\[\]%])/ URI::Escape::escape_char($1)/eg;
-                $val =~ s/ /+/g;
-                push(@query, "$key=$val");
+                if (defined $val) {
+                    $val =~ s/([;\/?:@&=+,\$\[\]%])/ URI::Escape::escape_char($1)/eg;
+                    $val =~ s/ /+/g;
+                    push(@query, "$key=$val");
+                }
+                else {
+                    push(@query, $key);
+                }
             }
         }
         if (@query) {
@@ -70,8 +74,8 @@ sub query_form {
     }
     return if !defined($old) || !length($old) || !defined(wantarray);
     return unless $old =~ /=/; # not a form
-    map { s/\+/ /g; uri_unescape($_) }
-         map { /=/ ? split(/=/, $_, 2) : ($_ => '')} split(/[&;]/, $old);
+    map { defined ? do { s/\+/ /g; uri_unescape($_) } : undef }
+         map { /=/ ? split(/=/, $_, 2) : ($_ => undef)} split(/[&;]/, $old);
 }
 
 # Handle ...?dog+bones type of query

--- a/t/old-base.t
+++ b/t/old-base.t
@@ -316,14 +316,14 @@ sub parts_test {
     );
 
     $url->query_form(a => undef, a => 'foo', '&=' => '&=+');
-    is($url->as_string, 'http://web?a=&a=foo&%26%3D=%26%3D%2B', ref($url) . '->as_string');
+    is($url->as_string, 'http://web?a&a=foo&%26%3D=%26%3D%2B', ref($url) . '->as_string');
 
     my @a = $url->query_form;
     is(scalar(@a), 6, 'length');
     is_deeply(
         \@a,
         [
-            'a', '',
+            'a', undef,
             'a', 'foo',
             '&=', '&=+',
         ],

--- a/t/query.t
+++ b/t/query.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 23;
+use Test::More tests => 26;
 
 use URI ();
 my $u = URI->new("", "http");
@@ -11,7 +11,7 @@ $u->query_form(a => 3, b => 4);
 is $u, "?a=3&b=4";
 
 $u->query_form(a => undef);
-is $u, "?a=";
+is $u, "?a";
 
 $u->query_form("a[=&+#] " => " [=&+#]");
 is $u, "?a%5B%3D%26%2B%23%5D+=+%5B%3D%26%2B%23%5D";
@@ -79,3 +79,11 @@ $u->query_form([]);
     $u->query_form(a => 1, b => 2);
 }
 is $u, "?a=1;b=2";
+
+$u->query('a&b=2');
+@q = $u->query_form;
+is join(":", @q), "a::b:2";
+ok !defined($q[1]);
+
+$u->query_form(@q);
+is $u,'?a&b=2';


### PR DESCRIPTION
This is a possible solution for #34

`query_form` now parses equal-less params, returning them as `$key => undef`. This also round-trips.

This is a change in interface, though: previously, `query_form(a=>undef)` would result in `?a=`, now it produces `?a` (which is going to be parsed as a keyword, not a form…)