### PR TITLE
Update cpanfile for Business::ISBN prerequisites

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -4,7 +4,7 @@ on 'configure' => sub {
 };
 
 on 'develop' => sub {
-    recommends 'Business::ISBN' => 0;
+    recommends 'Business::ISBN' => "3.005";
     recommends "Storable" => "0";
     requires "File::Spec" => "0";
     requires "IO::Handle" => "0";


### PR DESCRIPTION
Related to https://github.com/briandfoy/business-isbn-data/issues/8 and https://github.com/briandfoy/business-isbn-data/issues/7

Also note that older versions of Business::ISBN are not compatible Business::ISBN::Data since the edition of the 979 group. There's a lot of version switching in lib/URI/urn/isbn.pm.