### PR TITLE
WIP: Make URI::mailto parse subaddresses with + sign correctly

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Revision history for URI
 
 {{$NEXT}}
     - Remove Authority section from dist.ini (GH#86) (Olaf Alders)
+    - Make URI::mailto parse subaddresses with + sign correctly (GH#89) (Julien Fiegehenn)
 
 5.09      2021-03-03 15:16:47Z
     - Update Business::ISBN version requirements (GH#85) (brian d foy and Olaf

--- a/lib/URI/mailto.pm
+++ b/lib/URI/mailto.pm
@@ -38,7 +38,7 @@ sub to
 }
 
 
-sub headers
+sub headers 
 {
     my $self = shift;
 
@@ -68,6 +68,21 @@ sub headers
 
     # I am lazy today...
     URI->new("mailto:?$opaque")->query_form;
+}
+
+# https://datatracker.ietf.org/doc/html/rfc6068#section-5 requires 
+# plus signs (+) not to be turned into spaces
+sub query_form 
+{
+    my $self   = shift;
+    my @fields = $self->SUPER::query_form(@_);
+    for ( my $i = 0 ; $i < @fields ; $i += 2 ) {
+        if ( $fields[0] eq 'to' ) {
+            $fields[1] =~ s/ /+/g;
+            last;
+        }
+    }
+    return @fields;
 }
 
 1;

--- a/t/mailto.t
+++ b/t/mailto.t
@@ -44,4 +44,8 @@ $u = URI->new("mailto:");
 $u->to("gisle");
 is $u, 'mailto:gisle', 'starting with an empty URI and setting to() works';
 
+$u = URI->new('mailto:user+detail@example.com');
+is $u->to, 'user+detail@example.com', 'subaddress with `+` parsed correctly';
+is $u, 'mailto:user+detail@example.com', '... and stringification works';
+
 done_testing;

--- a/t/mailto.t
+++ b/t/mailto.t
@@ -48,4 +48,11 @@ $u = URI->new('mailto:user+detail@example.com');
 is $u->to, 'user+detail@example.com', 'subaddress with `+` parsed correctly';
 is $u, 'mailto:user+detail@example.com', '... and stringification works';
 
+TODO: {
+    local $TODO = "We can't handle quoted local parts without properly parsing the email addresses";
+    $u = URI->new('mailto:"foo bar+baz"@example.com');
+    is $u->to, '"foo bar+baz"@example.com', 'address with quoted local part containing spaces is parsed correctly';
+    is $u, 'mailto:%22foo%20bar+baz%22@example.com', '... and stringification works';
+}
+
 done_testing;

--- a/t/mailto.t
+++ b/t/mailto.t
@@ -1,48 +1,47 @@
 use strict;
 use warnings;
 
-print "1..7\n";
+use Test::More;
 
 use URI ();
 
 my $u = URI->new('mailto:gisle@aas.no');
-
-print "not " unless $u->to eq 'gisle@aas.no' &&
-                    $u eq 'mailto:gisle@aas.no';
-print "ok 1\n";
+is $u->to, 'gisle@aas.no', 'parsing normal URI sets to()';
+is $u, 'mailto:gisle@aas.no', '... and stringification works';
 
 my $old = $u->to('larry@wall.org');
-print "not " unless $old eq 'gisle@aas.no' &&
-                    $u->to eq 'larry@wall.org' &&
-		    $u eq 'mailto:larry@wall.org';
-print "ok 2\n";
+is $old, 'gisle@aas.no', 'to() returns old value';
+is $u->to, 'larry@wall.org', '... and sets new value';
+is $u, 'mailto:larry@wall.org', '... and stringification works';
 
 $u->to("?/#");
-print "not " unless $u->to eq "?/#" &&
-                    $u eq 'mailto:%3F/%23';
-print "ok 3\n";
+is $u->to, "?/#", 'to() accepts chars that need escaping';
+is $u, 'mailto:%3F/%23', '... and stringification escapes them';
 
 my @h = $u->headers;
-print "not " unless @h == 2 && "@h" eq "to ?/#";
-print "ok 4\n";
+ok @h == 2 && "@h" eq "to ?/#", '... and headers() returns the correct values';
 
-$u->headers(to      => 'gisle@aas.no',
-            cc      => 'gisle@ActiveState.com,larry@wall.org',
-            Subject => 'How do you do?',
-	    garbage => '/;?#=&',
+$u->headers(
+    to      => 'gisle@aas.no',
+    cc      => 'gisle@ActiveState.com,larry@wall.org',
+    Subject => 'How do you do?',
+    garbage => '/;?#=&',
 );
 
 @h = $u->headers;
-print "not " unless $u->to eq 'gisle@aas.no' &&
-                    @h == 8 &&
-                    "@h" eq 'to gisle@aas.no cc gisle@ActiveState.com,larry@wall.org Subject How do you do? garbage /;?#=&';
-print "ok 5\n";
+ok @h == 8
+  && "@h" eq
+'to gisle@aas.no cc gisle@ActiveState.com,larry@wall.org Subject How do you do? garbage /;?#=&',
+  'setting multiple headers at once works';
+is $u->to, 'gisle@aas.no', '... and to() returns the new value';
 
 #print "$u\n";
-print "not " unless $u eq 'mailto:gisle@aas.no?cc=gisle%40ActiveState.com%2Clarry%40wall.org&Subject=How+do+you+do%3F&garbage=%2F%3B%3F%23%3D%26';
-print "ok 6\n";
+is $u,
+'mailto:gisle@aas.no?cc=gisle%40ActiveState.com%2Clarry%40wall.org&Subject=How+do+you+do%3F&garbage=%2F%3B%3F%23%3D%26',
+  '... and stringification works';
 
 $u = URI->new("mailto:");
 $u->to("gisle");
-print "not " unless $u eq 'mailto:gisle';
-print "ok 7\n";
+is $u, 'mailto:gisle', 'starting with an empty URI and setting to() works';
+
+done_testing;


### PR DESCRIPTION
This appears to be a bit hacky, but I think it works well when we consider retaining the `query_form` behaviour.

Please note that we cannot deal with quote local parts of an email, such as `"foo bar"@example.org`, which [is valid](https://en.wikipedia.org/wiki/Email_address#Local-part). I've included a TODO test, but haven't described this behaviour. We don't have any documentation specifically for URI::mailto and this seems such an obscure feature of email addresses that I think we can live with it only being documented in code.

Fixes #89.