### PR TITLE
Change $DEFAULT_AUTHORITY to an undefined value

### DIFF
--- a/lib/URI/file.pm
+++ b/lib/URI/file.pm
@@ -8,7 +8,7 @@ our $VERSION = '5.11';
 
 use URI::Escape qw(uri_unescape);
 
-our $DEFAULT_AUTHORITY = "";
+our $DEFAULT_AUTHORITY;
 
 # Map from $^O values to implementation classes.  The Unix
 # class is the default.


### PR DESCRIPTION
When `URI::file` is loaded then calling, for example, `URI::file::Win32->new( q{C:\Documents\Some\Document.pdf} )` will not work as expected, because `URI::file::Win32->_file_extract_authority` has a condition whether `$URI::file::DEFAULT_AUTHORITY` is defined and `$URI::file::DEFAULT_AUTHORITY` is set in `URI::file` to an empty string, hence defined, thus the condition always returns true if `URI::file` is loaded.

As an example, consider:

```
perl -MURI -MURI::file::Win32 -lE 'say URI::file::Win32->new( q{C:\Documents\Some\Document.pdf} )'
```

would yield `file://C:/Documents/Some/Document.pdf` and calling `path` would rightfully produces `/Documents/Some/Document.pdf`

However, if I load URI::file, then look what happens:

```
perl -MURI -MURI::file -MURI::file::Win32 -lE 'say URI::file::Win32->new( q{C:\Documents\Some\Document.pdf} )->path'
```

This would yield: `file:///C:/Documents/Some/Document.pdf` and calling path would produce: `/C:/Documents/Some/Document.pdf`

The recommended solution would be to set the value of `$URI::file::DEFAULT_AUTHORITY` to undef, or leave it undefined and then it would work.