### PR TITLE
Allowing for leading and trailing whitespace in file URI

### DIFF
--- a/lib/URI/file/Base.pm
+++ b/lib/URI/file/Base.pm
@@ -20,7 +20,7 @@ sub new
 
     if (defined $auth) {
 	$auth =~ s,%,%25,g unless $escaped_auth;
-	$auth =~ s,([/?\#]), URI::Escape::escape_char($1),eg;
+	$auth =~ s,([/?\#\s]), URI::Escape::escape_char($1),eg;
 	$auth = "//$auth";
 	if (defined $path) {
 	    $path = "/$path" unless substr($path, 0, 1) eq "/";
@@ -32,7 +32,7 @@ sub new
 	$auth = "";
     }
 
-    $path =~ s,([%;?]), URI::Escape::escape_char($1),eg unless $escaped_path;
+    $path =~ s,([%;?\s]), URI::Escape::escape_char($1),eg unless $escaped_path;
     $path =~ s/\#/%23/g;
 
     my $uri = $auth . $path;

--- a/t/file.t
+++ b/t/file.t
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use URI::file;
+use File::Spec;
 
 my @tests =  (
 [ "file",          "unix",       "win32",         "mac" ],
@@ -27,7 +28,8 @@ my @tests =  (
 my @os = @{shift @tests};
 shift @os;  # file
 
-my $num = @tests;
+# Adding the one at the bottom
+my $num = @tests+1;
 print "1..$num\n";
 
 my $testno = 1;
@@ -47,13 +49,13 @@ for my $t (@tests) {
        my $loose;
        $loose++ if $expect =~ s/^!//;
        if ($expect ne $f) {
-           print "URI->new('$file', 'file')->file('$os') ne $expect, but $f\n";
+           print "URI->new('$file', 'file')->file('$os') ne '$expect', but '$f'\n";
            $err++;
        }
        if (defined($t[$i]) && !$loose) {
 	   my $u2 = URI::file->new($t[$i], $os);
            unless ($u2->as_string eq $file) {
-              print "URI::file->new('$t[$i]', '$os') ne $file, but $u2\n";
+              print "URI::file->new('$t[$i]', '$os') ne '$file', but '$u2'\n";
               $err++;
            }
        }
@@ -63,3 +65,14 @@ for my $t (@tests) {
    print "ok $testno\n";
    $testno++;
 }
+
+my $file = ' hello world ';
+my $u = URI::file->new_abs( $file );
+my @dirs = File::Spec->splitdir( $u->file( 'Unix' ) );
+print( "not " ) if( $dirs[-1] ne $file );
+print( "ok $num\n" );
+if( $dirs[-1] ne $file )
+{
+    printf( "# Failed test 'file with leading and trailing space'\n# at %s line %d.\n", __FILE__, ( __LINE__ - 6 ) );
+}
+


### PR DESCRIPTION
After adding `\s` as the special character to be percent-encoded as per rfc3986, the `URI::file` works fine. See the following test after modification:

```perl
#!/usr/local/bin/perl
use v5.10;
use URI::file;
use File::Spec;
my $file = ' hello world ';
my $u = URI::file->new_abs( $file );
my @dirs = File::Spec->splitdir( $u->file( 'Unix' ) );
say $dirs[-1] eq $file ? 'ok' : ( "not ok: '" . $dirs[-1] . "', expected '$file'" );
```

I also tested with the test units of the distribution and all came out ok.