### PR TITLE
Fix storable.t

### DIFF
--- a/.github/workflows/dzil-build-and-test.yml
+++ b/.github/workflows/dzil-build-and-test.yml
@@ -55,7 +55,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         perl-version:
-          # - "5.8" t/storable.t
+          - "5.8"
           - "5.10"
           - "5.12"
           - "5.14"
@@ -96,7 +96,7 @@ jobs:
       matrix:
         os: [macos-latest]
         perl-version:
-          # - "5.8" t/storable.t
+          - "5.8"
           - "5.10"
           - "5.12"
           - "5.14"

--- a/t/storable.t
+++ b/t/storable.t
@@ -4,7 +4,8 @@ use warnings;
 use Test::Needs 'Storable';
 print "1..3\n";
 
-system($^X, "-Iblib/lib", "t/storable-test.pl", "store");
-system($^X, "-Iblib/lib", "t/storable-test.pl", "retrieve");
+my $inc = -d "blib/lib" ? "blib/lib" : "lib";
+system($^X, "-I$inc", "t/storable-test.pl", "store");
+system($^X, "-I$inc", "t/storable-test.pl", "retrieve");
 
 unlink('urls.sto');


### PR DESCRIPTION
In github actions, we just run tests by `prove`, not `make && make test`.
So we should not assume the lib directory is `blib/lib`.

This PR fixes `t/storable.t` so that it chooses the proper lib directory.

NOTE
* `prove -l t/storable.t` accidentally passes on perl 5.10+, because `prove -l` exports PERL5LIB=lib
* OTOH, the `prove` on perl 5.8 is so old that it does not export PERL5LIB. Thus the test fails.