### PR TITLE
Regression test added for a previous bug (5.11) in URI::file

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Revision history for URI
 
 {{$NEXT}}
+    - Regression test added for a previous bug (5.11) in URI::file (Perlbotics).
+      file() method of URI::file can return the current working directory
+      instead of the properly unescaped path.
 
 5.12      2022-07-10 23:48:50Z
     - Fix an issue where i.e. 'file:///tmp/###' was not properly escaped.

--- a/t/file.t
+++ b/t/file.t
@@ -110,12 +110,31 @@ subtest "Regression Tests" => sub {
   # The empty string in turn caused URI::file->new_abs() to use the current
   # working directory as a default.
   {
-    my $sandbox_path = "/tmp/my sandbox";   # '%' in $good_uri causes the problem
-    my $file_uri     = URI::file->new_abs($sandbox_path);
+    my $test_loc     = $0 . ':' . __LINE__;
+    my $sandbox_unix = '/tmp/my sandbox';   # '%' in $good_uri causes the problem
+    my $sandbox_win  = '\tmp\my sandbox';
+    my $file_uri     = URI::file->new_abs($sandbox_unix);
     my $good_uri     = "file:///tmp/my%20sandbox";
 
     is( $file_uri,         $good_uri,     "file URI escaped correctly" );
-    is( $file_uri->file(), $sandbox_path, "got original filename (not current directory)" );
+
+    my $file_path = $file_uri->file();
+    $file_path    = '(undef)' unless defined $file_path;
+
+    if ( $file_path eq $sandbox_unix  or  $file_path eq $sandbox_win ) {
+      pass "got original filename for linux/windows";
+    } else {
+
+      my $current_dir = URI::file->new_abs('')->file();
+      if ( $file_path eq $current_dir ) {
+        fail "$test_loc: URI $URI::VERSION exposed a bug that could leak or destroy files on your system ($^O).";
+      } else {
+        diag "TODO: URI $URI::VERSION: A platform specific test on platform '$^O' with result '$file_path' "
+          .  "was skipped. Consider to notify maintainers ($test_loc).";
+      }
+
+    }
+
   }
 
 };

--- a/t/file.t
+++ b/t/file.t
@@ -110,31 +110,10 @@ subtest "Regression Tests" => sub {
   # The empty string in turn caused URI::file->new_abs() to use the current
   # working directory as a default.
   {
-    my $test_loc     = $0 . ':' . __LINE__;
-    my $sandbox_unix = '/tmp/my sandbox';   # '%' in $good_uri causes the problem
-    my $sandbox_win  = '\tmp\my sandbox';
-    my $file_uri     = URI::file->new_abs($sandbox_unix);
-    my $good_uri     = "file:///tmp/my%20sandbox";
+    my $file_path   = URI::file->new_abs('/a/path/that/pretty likely/does/not/exist-yie1Ahgh0Ohlahqueirequ0iebu8ip')->file();
+    my $current_dir = URI::file->new_abs()->file();
 
-    is( $file_uri,         $good_uri,     "file URI escaped correctly" );
-
-    my $file_path = $file_uri->file();
-    $file_path    = '(undef)' unless defined $file_path;
-
-    if ( $file_path eq $sandbox_unix  or  $file_path eq $sandbox_win ) {
-      pass "got original filename for linux/windows";
-    } else {
-
-      my $current_dir = URI::file->new_abs('')->file();
-      if ( $file_path eq $current_dir ) {
-        fail "$test_loc: URI $URI::VERSION exposed a bug that could leak or destroy files on your system ($^O).";
-      } else {
-        diag "TODO: URI $URI::VERSION: A platform specific test on platform '$^O' with result '$file_path' "
-          .  "was skipped. Consider to notify maintainers ($test_loc).";
-      }
-
-    }
-
+    isnt( $file_path, $current_dir, "URI $URI::VERSION exposes a bug that could leak or destroy files on your system ($^O)." );
   }
 
 };

--- a/t/file.t
+++ b/t/file.t
@@ -113,7 +113,7 @@ subtest "Regression Tests" => sub {
     my $file_path   = URI::file->new_abs('/a/path/that/pretty likely/does/not/exist-yie1Ahgh0Ohlahqueirequ0iebu8ip')->file();
     my $current_dir = URI::file->new_abs()->file();
 
-    isnt( $file_path, $current_dir, "URI $URI::VERSION exposes a bug that could leak or destroy files on your system ($^O)." );
+    isnt( $file_path, $current_dir, 'regression test for #102' );
   }
 
 };


### PR DESCRIPTION
Hi, perhaps you like to add this regression test to the URI module?
The bug is explained in detail in `t/file.t`.

The `Changes` paragraph:
 

>    - Regression test added for a previous bug (5.11) in URI::file (Perlbotics).
>       file() method of URI::file can return the current working directory
>       instead of the properly unescaped path.