### PR TITLE
Replace "Test" with "Test::More"

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,7 @@ Revision history for URI
     - Regression test added for a previous bug (5.11) in URI::file (Perlbotics).
       file() method of URI::file can return the current working directory
       instead of the properly unescaped path. (GH#106) (Perlbotics)
+    - Replace "Test" with "Test::More" (GH#107) (James Raspass)
 
 5.12      2022-07-10 23:48:50Z
     - Fix an issue where i.e. 'file:///tmp/###' was not properly escaped.

--- a/cpanfile
+++ b/cpanfile
@@ -45,7 +45,6 @@ on 'runtime' => sub {
 on 'test' => sub {
     requires "File::Spec::Functions" => "0";
     requires "File::Temp" => "0";
-    requires "Test" => "0";
     requires "Test::More" => "0.96";
     requires "Test::Needs" => '0';
     requires "utf8" => "0";

--- a/t/roy-test.t
+++ b/t/roy-test.t
@@ -1,8 +1,7 @@
 use strict;
 use warnings;
 
-use Test qw(ok plan);
-plan tests => 102;
+use Test::More tests => 102;
 
 use URI ();
 use File::Spec::Functions qw(catfile);
@@ -16,13 +15,13 @@ for my $i (1..5) {
    my $file = catfile(@prefix, "roytest$i.html");
 
    open(FILE, $file) || die "Can't open $file: $!";
-   print "# $file\n";
+   note $file;
    my $base = undef;
    while (<FILE>) {
        if (/^<BASE href="([^"]+)">/) {
            $base = URI->new($1);
        } elsif (/^<a href="([^"]*)">.*<\/a>\s*=\s*(\S+)/) {
-           die "Missing base at line $." unless $base;	    
+           die "Missing base at line $." unless $base;
            my $link = $1;
            my $exp  = $2;
            $exp = $base if $exp =~ /current/;  # special case test 22
@@ -35,7 +34,7 @@ for my $i (1..5) {
 	       $exp = "http://a/b/c/d;p?y";
 	   }
 
-	   ok(URI->new($link)->abs($base), $exp);
+	   is(URI->new($link)->abs($base), $exp);
 
            $no++;
        }


### PR DESCRIPTION
Test::More was already in use and provides a much nicer UX.

Amusingly this test was ported from raw TAP to `Test` in 2009 in 2e7c9087a4dd15ddd7f4fb161f9d2186577b6802, the `note` was missed, maybe it'll be ported to `Test2` in the future too, who knows :-)