### PR TITLE
uri_escape: allow characters to escape to be specified as a Regexp object

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for URI
 
 {{$NEXT}}
+    - Teach uri_escape to accept a Regexp object as the characters to escape
+      as an alternative to a character class.
 
 5.14      2022-10-10 20:37:57Z
     - Fix uri_escape allowing \w style character classes in its character set

--- a/lib/URI/Escape.pm
+++ b/lib/URI/Escape.pm
@@ -71,6 +71,13 @@ as the reserved characters.  I.e. the default is:
 
     "^A-Za-z0-9\-\._~"
 
+The second argument can also be specified as a regular expression object:
+
+  qr/[^A-Za-z]/
+
+Any strings matched by this regular expression will have all of their
+characters escaped.
+
 =item uri_escape_utf8( $string )
 
 =item uri_escape_utf8( $string, $unsafe )
@@ -162,6 +169,12 @@ sub uri_escape {
     return undef unless defined $text;
     my $re;
     if (defined $patn){
+        if (ref $patn eq 'Regexp') {
+            $text =~ s{($patn)}{
+                join('', map +($escapes{$_} || _fail_hi($_)), split //, "$1")
+            }ge;
+            return $text;
+        }
         $re = $subst{$patn};
         if (!defined $re) {
             $re = $patn;

--- a/t/escape.t
+++ b/t/escape.t
@@ -104,6 +104,18 @@ like join('', warnings {
 }xs,
   'bad escapes emit warnings';
 
+is
+    uri_escape ('abcd-[]', qr/[bc]/),
+    'a%62%63d-[]',
+    'allows regexp objects',
+    ;
+
+is
+    uri_escape ('a12b21c12d', qr/12/),
+    'a%31%32b21c%31%32d',
+    'allows regexp objects matching multiple characters',
+    ;
+
 is $escapes{"%"}, "%25";
 
 is uri_escape_utf8("|abcå"), "%7Cabc%C3%A5";


### PR DESCRIPTION
This is a replacement for #79, which also handles regexes that match more than a single character at a time. Also includes documentation.

I am unsure if this is a desirable feature.