### PR TITLE
Updated RFC references in the pod documentation for URI::file

### DIFF
--- a/lib/URI/file.pm
+++ b/lib/URI/file.pm
@@ -127,10 +127,8 @@ URI::file - URI that maps to local file names
 
 The C<URI::file> class supports C<URI> objects belonging to the I<file>
 URI scheme.  This scheme allows us to map the conventional file names
-found on various computer systems to the URI name space.  An old
-specification of the I<file> URI scheme is found in RFC 1738.  Some
-older background information is also in RFC 1630. There are no newer
-specifications as far as I know.
+found on various computer systems to the URI name space,
+see L<RFC 8089|https://www.rfc-editor.org/rfc/rfc8089.html>.
 
 If you simply want to construct I<file> URI objects from URI strings,
 use the normal C<URI> constructor.  If you want to construct I<file>
@@ -200,8 +198,9 @@ suitable for the local system:
 Most computer systems today have hierarchically organized file systems.
 Mapping the names used in these systems to the generic URI syntax
 allows us to work with relative file URIs that behave as they should
-when resolved using the generic algorithm for URIs (specified in RFC
-2396).  Mapping a file name to the generic URI syntax involves mapping
+when resolved using the generic algorithm for URIs (specified in L<RFC
+3986|https://www.rfc-editor.org/rfc/rfc3986.html>).
+Mapping a file name to the generic URI syntax involves mapping
 the path separator character to "/" and encoding any reserved
 characters that appear in the path segments of the file name.  If
 path segments consisting of the strings "." or ".." have a


### PR DESCRIPTION
Latest RFC version of the uri file scheme is RFC 8089, and latest version of RFC for generic URI syntax is RFC 3986.

_[[Assigned by [pullrequest.club](https://pullrequest.club/)]]_
