### PR TITLE
Remove use of Taint in tests.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Revision history for URI
 
 {{$NEXT}}
+   - Remove Shebang and Taint from all tests.
+   - Fix t/query.t to get rid of a warning about join() on
+      array with undef
 
 5.19      2023-04-30 16:15:58Z
    - Form parameters without values are now represented by undef (GH#65)

--- a/t/cwd.t
+++ b/t/cwd.t
@@ -1,5 +1,3 @@
-#!perl -T
-
 use strict;
 use warnings;
 

--- a/t/file.t
+++ b/t/file.t
@@ -1,5 +1,3 @@
-#!perl -T
-
 use strict;
 use warnings;
 

--- a/t/ipv6.t
+++ b/t/ipv6.t
@@ -1,5 +1,3 @@
-#!perl
-
 use strict;
 use warnings;
 

--- a/t/query.t
+++ b/t/query.t
@@ -82,7 +82,7 @@ is $u, "?a=1;b=2";
 
 $u->query('a&b=2');
 @q = $u->query_form;
-is join(":", @q), "a::b:2";
+is join(":", map { defined ? $_ : '' } @q), "a::b:2";
 ok !defined($q[1]);
 
 $u->query_form(@q);

--- a/t/query.t
+++ b/t/query.t
@@ -82,7 +82,7 @@ is $u, "?a=1;b=2";
 
 $u->query('a&b=2');
 @q = $u->query_form;
-is join(":", map { defined ? $_ : '' } @q), "a::b:2";
+is join(":", map { defined($_) ? $_ : '' } @q), "a::b:2";
 ok !defined($q[1]);
 
 $u->query_form(@q);


### PR DESCRIPTION
Also, ensure all tests files do not include the shebang.
t/query.t had a join() over an array with undef values; fix that.