### PR TITLE
use Scalar::Util::reftype instead of ref to check for ARRAY

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for URI
 
 {{$NEXT}}
+    - Use Scalar::Util::reftype instead of ref to check for ARRAY (GH#132)
+      (Jacques Deguest)
 
 5.21      2023-08-23 16:02:14Z
     - Fix version declarations in icap.pm and icaps.pm (GH#131) (Olaf Alders)

--- a/lib/URI/_query.pm
+++ b/lib/URI/_query.pm
@@ -5,6 +5,7 @@ use warnings;
 
 use URI ();
 use URI::Escape qw(uri_unescape);
+use Scalar::Util ();
 
 our $VERSION = '5.22';
 
@@ -34,7 +35,7 @@ sub query_form {
         # Try to set query string
         my $delim;
         my $r = $_[0];
-        if (ref($r) eq "ARRAY") {
+        if (Scalar::Util::reftype($r) eq "ARRAY") {
             $delim = $_[1];
             @_ = @$r;
         }
@@ -49,7 +50,7 @@ sub query_form {
             $key = '' unless defined $key;
 	    $key =~ s/([;\/?:@&=+,\$\[\]%])/ URI::Escape::escape_char($1)/eg;
 	    $key =~ s/ /+/g;
-	    $vals = [ref($vals) eq "ARRAY" ? @$vals : $vals];
+	    $vals = [Scalar::Util::reftype($vals) eq "ARRAY" ? @$vals : $vals];
             for my $val (@$vals) {
                 if (defined $val) {
                     $val =~ s/([;\/?:@&=+,\$\[\]%])/ URI::Escape::escape_char($1)/eg;
@@ -86,7 +87,7 @@ sub query_keywords
     if (@_) {
         # Try to set query string
 	my @copy = @_;
-	@copy = @{$copy[0]} if @copy == 1 && ref($copy[0]) eq "ARRAY";
+	@copy = @{$copy[0]} if @copy == 1 && Scalar::Util::reftype($copy[0]) eq "ARRAY";
 	for (@copy) { s/([;\/?:@&=+,\$\[\]%])/ URI::Escape::escape_char($1)/eg; }
 	$self->query(@copy ? join('+', @copy) : undef);
     }
@@ -114,7 +115,7 @@ sub query_param {
     if (@_) {
         my @new = @old;
         my @new_i = @i;
-        my @vals = map { ref($_) eq 'ARRAY' ? @$_ : $_ } @_;
+        my @vals = map { Scalar::Util::reftype($_) eq 'ARRAY' ? @$_ : $_ } @_;
 
         while (@new_i > @vals) {
             splice @new, pop @new_i, 2;
@@ -139,7 +140,7 @@ sub query_param {
 sub query_param_append {
     my $self = shift;
     my $key = shift;
-    my @vals = map { ref $_ eq 'ARRAY' ? @$_ : $_ } @_;
+    my @vals = map { Scalar::Util::reftype $_ eq 'ARRAY' ? @$_ : $_ } @_;
     $self->query_form($self->query_form, $key => \@vals);  # XXX
     return;
 }
@@ -168,7 +169,7 @@ sub query_form_hash {
     while (my($k, $v) = splice(@old, 0, 2)) {
         if (exists $hash{$k}) {
             for ($hash{$k}) {
-                $_ = [$_] unless ref($_) eq "ARRAY";
+                $_ = [$_] unless Scalar::Util::reftype($_) eq "ARRAY";
                 push(@$_, $v);
             }
         }


### PR DESCRIPTION
URI::_query uses `ref` to check if a value is an array, but since the URI distribution uses already `Scalar::Util`, I propose it uses `Scalar::Util::reftype` instead.