### PR TITLE
Revert "URI-5.22"

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for URI
 
 {{$NEXT}}
+    - Revert the reftype change introduced in 5.22 as it causes warnings.
+      (GH#134) (Olaf Alders)
 
 5.22      2024-01-25 15:22:54Z
     - Use Scalar::Util::reftype instead of ref to check for ARRAY (GH#132)


### PR DESCRIPTION
This reverts commit fc3628dc281304cb843a2c00799a7a8682fd1d51.

The following warnings were introduced:

```
Use of uninitialized value in string eq at /root/.cpan/build/URI-5.22-0/blib/lib/URI/_query.pm line 38.
Use of uninitialized value in string eq at /root/.cpan/build/URI-5.22-0/blib/lib/URI/_query.pm line 53.
Use of uninitialized value in string eq at /root/.cpan/build/URI-5.22-0/blib/lib/URI/_query.pm line 118.
Use of uninitialized value in string eq at /root/.cpan/build/URI-5.22-0/blib/lib/URI/_query.pm line 172.
```

@jackdeguest FYI ^^^