### PR TITLE
Using Scalar::Util::reftype instead of just ref(), but mindful this time about definedness to avoid warnings

### DIFF
--- a/lib/URI/_query.pm
+++ b/lib/URI/_query.pm
@@ -50,7 +50,7 @@ sub query_form {
             $key = '' unless defined $key;
 	    $key =~ s/([;\/?:@&=+,\$\[\]%])/ URI::Escape::escape_char($1)/eg;
 	    $key =~ s/ /+/g;
-	    $vals = [(defined($vals) && (Scalar::Util::reftype($vals) || '') eq "ARRAY") ? @$vals : $vals];
+	    $vals = [(defined($vals) && (Scalar::Util::reftype($vals) || '') eq "ARRAY" && !( Scalar::Util::blessed( $vals ) && overload::Method( $vals, '""' ) ) ) ? @$vals : $vals];
             for my $val (@$vals) {
                 if (defined $val) {
                     $val =~ s/([;\/?:@&=+,\$\[\]%])/ URI::Escape::escape_char($1)/eg;
@@ -87,7 +87,7 @@ sub query_keywords
     if (@_) {
         # Try to set query string
 	my @copy = @_;
-	@copy = @{$copy[0]} if @copy == 1 && defined($copy[0]) && (Scalar::Util::reftype($copy[0]) || '') eq "ARRAY";
+	@copy = @{$copy[0]} if @copy == 1 && defined($copy[0]) && (Scalar::Util::reftype($copy[0]) || '') eq "ARRAY" && !( Scalar::Util::blessed( $copy[0] ) && overload::Method( $copy[0], '""' ) );
 	for (@copy) { s/([;\/?:@&=+,\$\[\]%])/ URI::Escape::escape_char($1)/eg; }
 	$self->query(@copy ? join('+', @copy) : undef);
     }
@@ -115,7 +115,7 @@ sub query_param {
     if (@_) {
         my @new = @old;
         my @new_i = @i;
-        my @vals = map { (defined($_) && (Scalar::Util::reftype($_) || '') eq 'ARRAY') ? @$_ : $_ } @_;
+        my @vals = map { (defined($_) && (Scalar::Util::reftype($_) || '') eq 'ARRAY' && !( Scalar::Util::blessed( $_ ) && overload::Method( $_, '""' ) )) ? @$_ : $_ } @_;
 
         while (@new_i > @vals) {
             splice @new, pop @new_i, 2;
@@ -140,7 +140,7 @@ sub query_param {
 sub query_param_append {
     my $self = shift;
     my $key = shift;
-    my @vals = map { (defined($_) && (Scalar::Util::reftype($_) || '') eq 'ARRAY') ? @$_ : $_ } @_;
+    my @vals = map { (defined($_) && (Scalar::Util::reftype($_) || '') eq 'ARRAY' && !( Scalar::Util::blessed( $_ ) && overload::Method( $_, '""' ) )) ? @$_ : $_ } @_;
     $self->query_form($self->query_form, $key => \@vals);  # XXX
     return;
 }
@@ -169,7 +169,7 @@ sub query_form_hash {
     while (my($k, $v) = splice(@old, 0, 2)) {
         if (exists $hash{$k}) {
             for ($hash{$k}) {
-                $_ = [$_] unless(defined($_) && (Scalar::Util::reftype($_) || '') eq "ARRAY");
+                $_ = [$_] unless(defined($_) && (Scalar::Util::reftype($_) || '') eq "ARRAY" && !( Scalar::Util::blessed( $_ ) && overload::Method( $_, '""' ) ));
                 push(@$_, $v);
             }
         }

--- a/lib/URI/_query.pm
+++ b/lib/URI/_query.pm
@@ -5,6 +5,7 @@ use warnings;
 
 use URI ();
 use URI::Escape qw(uri_unescape);
+use Scalar::Util ();
 
 our $VERSION = '5.26';
 
@@ -34,7 +35,7 @@ sub query_form {
         # Try to set query string
         my $delim;
         my $r = $_[0];
-        if (ref($r) eq "ARRAY") {
+        if (defined($r) && (Scalar::Util::reftype($r) || '') eq "ARRAY") {
             $delim = $_[1];
             @_ = @$r;
         }
@@ -49,7 +50,7 @@ sub query_form {
             $key = '' unless defined $key;
 	    $key =~ s/([;\/?:@&=+,\$\[\]%])/ URI::Escape::escape_char($1)/eg;
 	    $key =~ s/ /+/g;
-	    $vals = [ref($vals) eq "ARRAY" ? @$vals : $vals];
+	    $vals = [(defined($vals) && (Scalar::Util::reftype($vals) || '') eq "ARRAY") ? @$vals : $vals];
             for my $val (@$vals) {
                 if (defined $val) {
                     $val =~ s/([;\/?:@&=+,\$\[\]%])/ URI::Escape::escape_char($1)/eg;
@@ -86,7 +87,7 @@ sub query_keywords
     if (@_) {
         # Try to set query string
 	my @copy = @_;
-	@copy = @{$copy[0]} if @copy == 1 && ref($copy[0]) eq "ARRAY";
+	@copy = @{$copy[0]} if @copy == 1 && defined($copy[0]) && (Scalar::Util::reftype($copy[0]) || '') eq "ARRAY";
 	for (@copy) { s/([;\/?:@&=+,\$\[\]%])/ URI::Escape::escape_char($1)/eg; }
 	$self->query(@copy ? join('+', @copy) : undef);
     }
@@ -114,7 +115,7 @@ sub query_param {
     if (@_) {
         my @new = @old;
         my @new_i = @i;
-        my @vals = map { ref($_) eq 'ARRAY' ? @$_ : $_ } @_;
+        my @vals = map { (defined($_) && (Scalar::Util::reftype($_) || '') eq 'ARRAY') ? @$_ : $_ } @_;
 
         while (@new_i > @vals) {
             splice @new, pop @new_i, 2;
@@ -139,7 +140,7 @@ sub query_param {
 sub query_param_append {
     my $self = shift;
     my $key = shift;
-    my @vals = map { ref $_ eq 'ARRAY' ? @$_ : $_ } @_;
+    my @vals = map { (defined($_) && (Scalar::Util::reftype($_) || '') eq 'ARRAY') ? @$_ : $_ } @_;
     $self->query_form($self->query_form, $key => \@vals);  # XXX
     return;
 }
@@ -168,7 +169,7 @@ sub query_form_hash {
     while (my($k, $v) = splice(@old, 0, 2)) {
         if (exists $hash{$k}) {
             for ($hash{$k}) {
-                $_ = [$_] unless ref($_) eq "ARRAY";
+                $_ = [$_] unless(defined($_) && (Scalar::Util::reftype($_) || '') eq "ARRAY");
                 push(@$_, $v);
             }
         }

--- a/lib/URI/_query.pm
+++ b/lib/URI/_query.pm
@@ -35,7 +35,7 @@ sub query_form {
         # Try to set query string
         my $delim;
         my $r = $_[0];
-        if (defined($r) && (Scalar::Util::reftype($r) || '') eq "ARRAY") {
+        if (_is_array($r)) {
             $delim = $_[1];
             @_ = @$r;
         }
@@ -50,7 +50,7 @@ sub query_form {
             $key = '' unless defined $key;
 	    $key =~ s/([;\/?:@&=+,\$\[\]%])/ URI::Escape::escape_char($1)/eg;
 	    $key =~ s/ /+/g;
-	    $vals = [(defined($vals) && (Scalar::Util::reftype($vals) || '') eq "ARRAY" && !( Scalar::Util::blessed( $vals ) && overload::Method( $vals, '""' ) ) ) ? @$vals : $vals];
+	    $vals = [_is_array($vals) ? @$vals : $vals];
             for my $val (@$vals) {
                 if (defined $val) {
                     $val =~ s/([;\/?:@&=+,\$\[\]%])/ URI::Escape::escape_char($1)/eg;
@@ -87,7 +87,7 @@ sub query_keywords
     if (@_) {
         # Try to set query string
 	my @copy = @_;
-	@copy = @{$copy[0]} if @copy == 1 && defined($copy[0]) && (Scalar::Util::reftype($copy[0]) || '') eq "ARRAY" && !( Scalar::Util::blessed( $copy[0] ) && overload::Method( $copy[0], '""' ) );
+	@copy = @{$copy[0]} if @copy == 1 && _is_array($copy[0]);
 	for (@copy) { s/([;\/?:@&=+,\$\[\]%])/ URI::Escape::escape_char($1)/eg; }
 	$self->query(@copy ? join('+', @copy) : undef);
     }
@@ -115,7 +115,7 @@ sub query_param {
     if (@_) {
         my @new = @old;
         my @new_i = @i;
-        my @vals = map { (defined($_) && (Scalar::Util::reftype($_) || '') eq 'ARRAY' && !( Scalar::Util::blessed( $_ ) && overload::Method( $_, '""' ) )) ? @$_ : $_ } @_;
+        my @vals = map { _is_array($_) ? @$_ : $_ } @_;
 
         while (@new_i > @vals) {
             splice @new, pop @new_i, 2;
@@ -140,7 +140,7 @@ sub query_param {
 sub query_param_append {
     my $self = shift;
     my $key = shift;
-    my @vals = map { (defined($_) && (Scalar::Util::reftype($_) || '') eq 'ARRAY' && !( Scalar::Util::blessed( $_ ) && overload::Method( $_, '""' ) )) ? @$_ : $_ } @_;
+    my @vals = map { _is_array($_) ? @$_ : $_ } @_;
     $self->query_form($self->query_form, $key => \@vals);  # XXX
     return;
 }
@@ -169,7 +169,7 @@ sub query_form_hash {
     while (my($k, $v) = splice(@old, 0, 2)) {
         if (exists $hash{$k}) {
             for ($hash{$k}) {
-                $_ = [$_] unless(defined($_) && (Scalar::Util::reftype($_) || '') eq "ARRAY" && !( Scalar::Util::blessed( $_ ) && overload::Method( $_, '""' ) ));
+                $_ = [$_] unless _is_array($_);
                 push(@$_, $v);
             }
         }
@@ -178,6 +178,17 @@ sub query_form_hash {
         }
     }
     return \%hash;
+}
+
+sub _is_array {
+    return(
+        defined($_[0]) &&
+        ( Scalar::Util::reftype($_[0]) || '' ) eq "ARRAY" && 
+        !(
+            Scalar::Util::blessed( $_[0] ) && 
+            overload::Method( $_[0], '""' )
+        )
+    );
 }
 
 1;

--- a/t/old-base.t
+++ b/t/old-base.t
@@ -348,6 +348,19 @@ sub parts_test {
     $url->query_form(a => ['foo', 'bar'], b => 'foo', c => ['bar', 'foo']);
     is($url->as_string, 'http://web?a=foo&a=bar&b=foo&c=bar&c=foo', ref($url) . '->as_string');
 
+    # Same, but using array object
+    {
+        package
+            Foo::Bar::Array;
+        sub new
+        {
+            my $this = shift( @_ );
+            return( bless( ( @_ == 1 && ref( $_[0] || '' ) eq 'ARRAY' ) ? shift( @_ ) : [@_] => ( ref( $this ) || $this ) ) );
+        }
+    }
+    $url->query_form(a => Foo::Bar::Array->new(['foo', 'bar']), b => 'foo', c => Foo::Bar::Array->new(['bar', 'foo']));
+    is($url->as_string, 'http://web?a=foo&a=bar&b=foo&c=bar&c=foo', ref($url) . '->as_string');
+
     subtest 'netloc_test' => \&netloc_test;
     subtest 'port_test' => \&port_test;
 

--- a/t/query-param.t
+++ b/t/query-param.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 19;
+use Test::More tests => 20;
 
 use URI ();
 use URI::QueryParam;
@@ -65,6 +65,21 @@ is $u->query, 'a=1&a=2&a=3&b=1';
 
 $u->query_param('a' => []);
 $u->query_param('b' => []);
+
+ok ! $u->query;
+
+# Same, but using array object
+{
+    package
+        Foo::Bar::Array;
+    sub new
+    {
+        my $this = shift( @_ );
+        return( bless( ( @_ == 1 && ref( $_[0] || '' ) eq 'ARRAY' ) ? shift( @_ ) : [@_] => ( ref( $this ) || $this ) ) );
+    }
+}
+$u->query_param('a' => Foo::Bar::Array->new);
+$u->query_param('b' => Foo::Bar::Array->new);
 
 ok ! $u->query;
 


### PR DESCRIPTION
I have been careful this time to check for variable defined-ness before using `Scalar::Util::reftype` and also since `Scalar::Util::reftype` returns `undef` when false, I made sure to use an empty string by default in equality checks, such as `(Scalar::Util::reftype($r) || '') eq 'ARRAY'`

I have performed all the test units and all went well.

The advantage of using `Scalar::Util::reftype` over just `ref` is when one is using array objects. Using just `ref` would return the object class whereas using `Scalar::util::reftype` returns the type as expected, and works for regular arrays as well as array objects.