### PR TITLE
Add missing NAME section to POD of URI::geo

### DIFF
--- a/lib/URI/geo.pm
+++ b/lib/URI/geo.pm
@@ -232,6 +232,10 @@ sub _path {
 
 __END__
 
+=head1 NAME
+
+URI::geo - URI scheme for geo Identifiers
+
 =head1 SYNOPSIS
 
   use URI;


### PR DESCRIPTION

In Debian we are currently applying the following patch to URI.
We thought you might be interested in it too.

    Description: Add missing NAME section to POD of URI::geo
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2024-02-09
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/liburi-perl/raw/master/debian/patches/uri-geo-pod.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
