### PR TITLE
CI: tune dependabot and bump to Perl 5.42

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,11 +7,6 @@ updates:
     # Check for updates to GitHub Actions every week
     interval: "weekly"
   groups:
-    major-updates:
-      patterns:
-        - "*"
-      update-types:
-        - "major"
     minor-and-patch:
       patterns:
         - "*"


### PR DESCRIPTION
## Summary
- Bump `build-job` and `coverage-job` containers from `perldocker/perl-tester:5.34` to `5.42`, and add Perl 5.42 to the test matrix.
- Tune dependabot for the `github-actions` ecosystem: group minor/patch updates into a single weekly PR, leave majors as individual PRs (default), and add a 7-day cooldown so churning releases settle before a PR opens.
- Restrict the `push` trigger to `master` only and remove the `pull_request` branch filter, so PRs from feature branches build once instead of twice.
- Drop the `nektos/act` guard on the artifact upload (not used in this repo).

## Test plan
- [ ] CI build-job and coverage-job pass on Perl 5.42
- [ ] Matrix run for Perl 5.42 across the default distribution succeeds (Strawberry 5.42 on Windows may need adding to `exclude:` if `shogo82148/actions-setup-perl` doesn't have it yet — follow-up if so)
- [ ] No duplicate runs on this PR — exactly one workflow run triggered by the `pull_request` event
- [ ] Next dependabot cycle produces a grouped minor/patch PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)