### PR TITLE
Don't require Test::Fatal on perl < 5.12

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for URI
 
 {{$NEXT}}
+    - Only require Test::Fatal on perl >= 5.12 (where it can be installed),
+      so tests still pass on older perls (GH#166) (GH#177)
 
 5.35      2026-06-14 23:04:12Z
     - Strip leading zeros from port numbers in canonical URIs (GH#69) (GH#162)

--- a/cpanfile
+++ b/cpanfile
@@ -47,9 +47,15 @@ on 'runtime' => sub {
 on 'test' => sub {
     requires "File::Spec::Functions" => "0";
     requires "File::Temp" => "0";
-    requires "Test::Fatal" => "0";
     requires "Test::More" => "0.96";
     requires "Test::Needs" => '0';
     requires "Test::Warnings" => '0';
     requires "utf8" => "0";
+
+    # Test::Fatal 0.18+ requires perl 5.12, but URI still supports older
+    # perls. Require it where it can be installed so the relevant test
+    # always runs; on older perls t/escape.t skips that test via Test::Needs.
+    if ( "$]" >= 5.012 ) {
+        requires "Test::Fatal" => "0";
+    }
 };

--- a/t/escape.t
+++ b/t/escape.t
@@ -2,8 +2,8 @@ use strict;
 use warnings;
 
 use Test::More;
+use Test::Needs;
 use Test::Warnings qw( :all );
-use Test::Fatal;
 
 use URI::Escape qw( %escapes uri_escape uri_escape_utf8 uri_unescape );
 
@@ -87,9 +87,12 @@ is
     'regex characters like / and ^ allowed in range'
     ;
 
-like exception { uri_escape ('abcdef', 'd-c') },
-  qr/Invalid \[\] range "d-c" in regex/,
-  'invalid range with max less than min throws exception';
+subtest 'invalid range throws exception' => sub {
+    test_needs 'Test::Fatal';
+    like Test::Fatal::exception( sub { uri_escape ('abcdef', 'd-c') } ),
+      qr/Invalid \[\] range "d-c" in regex/,
+      'invalid range with max less than min throws exception';
+};
 
 like join('', warnings {
     is


### PR DESCRIPTION
## Problem

`Test::Fatal` 0.18+ requires perl v5.12 (it swapped `use strict` for `use v5.12`). Because URI listed `Test::Fatal` as an unconditional test dependency, the test suite fails to run on perl 5.8 and 5.10 even though URI itself supports those versions.

`Test::Fatal` was used in exactly one place: a single assertion in `t/escape.t`.

## Fix

- Make the `Test::Fatal` test prereq **conditional on perl >= 5.12** in the `cpanfile` (a cpanfile is evaluated Perl, so `if ( "$]" >= 5.012 )` works). Fresh installs on supported perls still pull it in and run the test; older perls omit it.
- Guard the single assertion with `Test::Needs` (already a test prereq) so that on perls where `Test::Fatal` isn't installed, the subtest is skipped and the rest of `t/escape.t` still runs. The call is `Test::Fatal::exception( sub { ... } )` with no top-level import (`test_needs` itself `require`s the module when available).

This keeps full test coverage on modern perls while unblocking the suite on 5.8/5.10.

Closes #166
Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)