### PR TITLE
Normalize IDNA labels with NFC in nameprep

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,10 @@
 Revision history for URI
 
 {{$NEXT}}
+    - Apply Unicode NFC normalization in URI::_idna nameprep so IDNA host
+      encoding matches other clients instead of emitting a non-standard,
+      non-round-tripping A-label [CVE-2026-19953] (reported by Naseeb Dangi,
+      @naseeb0) (GH#191)
 
 5.35      2026-06-14 23:04:12Z
     - Strip leading zeros from port numbers in canonical URIs (GH#69) (GH#162)

--- a/cpanfile
+++ b/cpanfile
@@ -32,6 +32,7 @@ on 'runtime' => sub {
     requires "MIME::Base64" => "2";
     requires "Net::Domain" => "0";
     requires "Scalar::Util" => "0";
+    requires "Unicode::Normalize" => "0";
     requires "constant" => "0";
     requires "integer" => "0";
     requires "overload" => "0";

--- a/lib/URI/_idna.pm
+++ b/lib/URI/_idna.pm
@@ -6,8 +6,9 @@ package URI::_idna;
 use strict;
 use warnings;
 
-use URI::_punycode qw(decode_punycode encode_punycode);
-use Carp           qw(croak);
+use URI::_punycode     qw(decode_punycode encode_punycode);
+use Unicode::Normalize qw(NFC);
+use Carp               qw(croak);
 
 our $VERSION = '5.36';
 
@@ -37,10 +38,20 @@ sub decode {
     return join(".", map ToUnicode($_), split(/\./, $domain, -1));
 }
 
-sub nameprep {    # XXX real implementation missing
+sub nameprep {
     my $label = shift;
-    $label = lc($label);
-    return $label;
+
+    # Lowercase, then normalize. Without normalization a non-NFC label encodes
+    # to a non-standard A-label that other IDNA implementations reject, so a
+    # host used for a security check can differ from the host actually fetched.
+    # We normalize with NFC (canonical composition): RFC 3491 (IDNA2003)
+    # nominally called for NFKC, but RFC 5891 (IDNA2008) replaced that with NFC,
+    # which is also what UTS #46 applies in browsers and other clients. The
+    # prohibited-character and bidi tables that a full nameprep would enforce
+    # remain unimplemented. A host passed as bytes rather than decoded
+    # characters is treated as Latin-1 per URI's documented contract (see the
+    # host/ihost examples in URI.pm), so pass decoded characters for UTF-8.
+    return NFC(lc $label);
 }
 
 sub check_size {

--- a/t/idna.t
+++ b/t/idna.t
@@ -2,8 +2,9 @@ use strict;
 use warnings;
 
 use utf8;
-use Test::More tests => 7;
-use URI::_idna ();
+use Test::More;
+use Test::Fatal qw( exception );
+use URI::_idna  ();
 
 is URI::_idna::encode("www.example.com"),  "www.example.com";
 is URI::_idna::decode("www.example.com"),  "www.example.com";
@@ -12,3 +13,20 @@ is URI::_idna::decode("www.example.com."), "www.example.com.";
 is URI::_idna::encode("Bücher.ch"),        "xn--bcher-kva.ch";
 is URI::_idna::decode("xn--bcher-kva.ch"), "bücher.ch";
 is URI::_idna::decode("xn--bcher-KVA.ch"), "bücher.ch";
+
+# nameprep must NFC-normalize a label before punycode encoding: a non-NFC
+# label otherwise encodes to a non-standard A-label that a security check and
+# the eventual fetch can disagree about.
+is URI::_idna::encode(chr(0x0958) . chr(0x093E)), "xn--11b2fg",
+    "precomposed Devanagari sequence is NFC-normalized before encoding";
+
+# The correct (NFC) A-label decodes and re-encodes back to itself.
+is URI::_idna::encode(URI::_idna::decode("xn--11b2fg")), "xn--11b2fg",
+    "NFC A-label round-trips through decode/encode";
+
+# The non-normalized precomposed A-label for the same name must be rejected
+# rather than silently decoded, so it can never stand in for the NFC host.
+like exception { URI::_idna::decode("xn--72b5c") }, qr/does not round-trip/,
+    "non-NFC A-label is rejected on decode";
+
+done_testing;


### PR DESCRIPTION
## Problem

`URI::_idna::nameprep` only lowercased the label and skipped the Unicode
normalization that RFC 3490/3491 require (it carried a `# XXX real
implementation missing` marker). Because of this, a host that is not already in
NFC encodes to a non-standard A-label that disagrees with what browsers, curl,
Go, Java, and Python compute for the same input — and the resulting A-label does
not round-trip.

Example (precomposed Devanagari QA, U+0958):

```
perl -CS -MURI -e 'print URI->new("http://".chr(0x0958).chr(0x093E).".example/")->host'
```

| | host |
|---|---|
| URI (before) | `xn--72b5c.example` |
| Everyone else (browsers, curl, Go, Java, Python) | `xn--11b2fg.example` |

Code that reads the host from a URL for a comparison (allow/deny lists, dedup,
cache keys, request routing) can therefore disagree with whatever actually
fetches the URL.

## Fix

Apply `Unicode::Normalize::NFC` in `nameprep`, so the encoded host matches other
IDNA implementations.

**NFC vs NFKC:** RFC 3491 nominally specifies NFKC, but `URI` still passes
byte-string hosts through this path and NFKC's compatibility mappings corrupt
them (e.g. byte `0xBC` → `¼` → `1⁄4`), regressing existing `t/iri.t` behavior.
NFC applies only canonical decompositions, which fixes the reported divergence
while leaving those byte inputs intact — and NFC also matches the normalization
UTS #46 uses in browsers.

A full nameprep would additionally enforce the prohibited-character and bidi
tables; those remain unimplemented and are out of scope here.

## Notes

- `Unicode::Normalize` added to runtime prereqs (core since Perl 5.8, so no
  version floor given the 5.008001 minimum).
- New tests in `t/idna.t` cover the normalization and A-label round-trip.
- Full suite passes (1035 tests); `precious tidy`/`lint` clean.