### PR TITLE
Drop Test::Fatal to unblock the test suite on perl < 5.12

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -48,7 +48,6 @@ on 'runtime' => sub {
 on 'test' => sub {
     requires "File::Spec::Functions" => "0";
     requires "File::Temp" => "0";
-    requires "Test::Fatal" => "0";
     requires "Test::More" => "0.96";
     requires "Test::Needs" => '0';
     requires "Test::Warnings" => '0';

--- a/t/escape.t
+++ b/t/escape.t
@@ -3,7 +3,6 @@ use warnings;
 
 use Test::More;
 use Test::Warnings qw( :all );
-use Test::Fatal;
 
 use URI::Escape qw( %escapes uri_escape uri_escape_utf8 uri_unescape );
 
@@ -54,8 +53,12 @@ is uri_escape('abcd-', '\w'), '%61%62%63%64-',
 is uri_escape('a/b`]c^', '/-^'), 'a%2Fb`%5Dc%5E',
     'regex characters like / and ^ allowed in range';
 
-like exception { uri_escape('abcdef', 'd-c') },
-    qr/Invalid \[\] range "d-c" in regex/,
+my $exception = do {
+    local $@;
+    eval { uri_escape('abcdef', 'd-c') };
+    $@;
+};
+like $exception, qr/Invalid \[\] range "d-c" in regex/,
     'invalid range with max less than min throws exception';
 
 like join(

--- a/t/idna.t
+++ b/t/idna.t
@@ -3,8 +3,7 @@ use warnings;
 
 use utf8;
 use Test::More;
-use Test::Fatal qw( exception );
-use URI::_idna  ();
+use URI::_idna ();
 
 is URI::_idna::encode("www.example.com"),  "www.example.com";
 is URI::_idna::decode("www.example.com"),  "www.example.com";
@@ -26,7 +25,12 @@ is URI::_idna::encode(URI::_idna::decode("xn--11b2fg")), "xn--11b2fg",
 
 # The non-normalized precomposed A-label for the same name must be rejected
 # rather than silently decoded, so it can never stand in for the NFC host.
-like exception { URI::_idna::decode("xn--72b5c") }, qr/does not round-trip/,
+my $exception = do {
+    local $@;
+    eval { URI::_idna::decode("xn--72b5c") };
+    $@;
+};
+like $exception, qr/does not round-trip/,
     "non-NFC A-label is rejected on decode";
 
 done_testing;


### PR DESCRIPTION
Closes #166
Closes #177
Closes #182

## Changes
- Replace the two `Test::Fatal::exception { ... }` call sites (`t/escape.t`, `t/idna.t`) with plain `eval { ... }; $@` — no external dependency needed, works unconditionally on perl 5.8+.
- Remove `Test::Fatal` from `cpanfile's test prereqs, since nothing in the suite uses it anymore.

`Test::Fatal` 0.18+ requires perl v5.12+ (it swapped `use strict` for `use v5.12`), so it broke the test suite on 5.8/5.10 even though URI itself supports those perls.

## Testing
- Full test suite passes: `prove -Ilib -r t/` — 1036 tests, 0 failures.
- Confirmed no remaining `Test::Fatal` references anywhere in the repo.
- `precious lint`/`precious tidy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code) · Sonnet 5