### PR TITLE
Keep $VERSION line tidy across post-release version bumps

### DIFF
--- a/lib/URI/Escape.pm
+++ b/lib/URI/Escape.pm
@@ -148,6 +148,7 @@ use Exporter 5.57 'import';
 our %escapes;
 our @EXPORT    = qw(uri_escape uri_unescape uri_escape_utf8);
 our @EXPORT_OK = qw(%escapes);
+
 our $VERSION = '5.37';
 
 use Carp ();

--- a/lib/URI/Heuristic.pm
+++ b/lib/URI/Heuristic.pm
@@ -91,6 +91,7 @@ use warnings;
 
 use Exporter 5.57 'import';
 our @EXPORT_OK = qw(uf_uri uf_uristr uf_url uf_urlstr);
+
 our $VERSION = '5.37';
 
 our ($MY_COUNTRY, $DEBUG);


### PR DESCRIPTION
The `precious lint` CI job broke on `master` after the post-release version bump.

## Root cause

Dist::Zilla's `BumpVersionAfterRelease` (via `[@Git::VersionManager]`) rewrites the `$VERSION` line at release time with a single space around `=`. In `Escape.pm` and `Heuristic.pm`, `$VERSION` sat directly beneath an `our @EXPORT...` line, so perltidy had vertically **aligned** the two assignments. The bump collapsed that alignment, and perltidy's `--assert-tidy` then failed wanting the aligned form.

This is recurring by nature — it would break again on every release.

## Fix

Put a blank line between the `@EXPORT` block and `$VERSION`. perltidy only vertically aligns *consecutive* assignments, so a standalone `$VERSION` line stays tidy no matter how the bump rewrites it. This matches how `URI.pm` and the other passing modules already lay out `$VERSION`.

Verified by simulating a future bump (rewriting to a single-space `$VERSION`): `precious lint` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)